### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,36 +1,41 @@
 {
-    "name":        "grunt-util-digest",
-    "homepage":    "http://github.com/rse/grunt-util-digest",
+    "name": "grunt-util-digest",
+    "homepage": "http://github.com/rse/grunt-util-digest",
     "description": "Grunt Plugin for calculating Message Digest of Source Files",
-    "version":     "0.9.2",
-    "license":     "MIT",
+    "version": "0.9.2",
+    "license": "MIT",
     "author": {
-        "name":    "Ralf S. Engelschall",
-        "email":   "rse@engelschall.com",
-        "url":     "http://engelschall.com"
+        "name": "Ralf S. Engelschall",
+        "email": "rse@engelschall.com",
+        "url": "http://engelschall.com"
     },
     "keywords": [
         "gruntplugin",
-        "message", "digest", "md5", "sha1", "source", "file"
+        "message",
+        "digest",
+        "md5",
+        "sha1",
+        "source",
+        "file"
     ],
     "repository": {
         "type": "git",
-        "url":  "git://github.com/rse/grunt-util-digest.git"
+        "url": "git://github.com/rse/grunt-util-digest.git"
     },
     "bugs": {
-        "url":  "http://github.com/rse/grunt-util-digest/issues"
+        "url": "http://github.com/rse/grunt-util-digest/issues"
     },
     "main": "Gruntfile.js",
     "devDependencies": {
-        "grunt":                "~0.4.5",
-        "grunt-cli":            "~0.1.13",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
         "grunt-contrib-jshint": "~0.11.3",
-        "grunt-contrib-clean":  "~0.7.0"
+        "grunt-contrib-clean": "~0.7.0"
     },
     "peerDependencies": {
-        "grunt":                "~0.4.5"
+        "grunt": ">=0.4.0"
     },
     "engines": {
-        "node":                 ">=0.10.0"
+        "node": ">=0.10.0"
     }
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
